### PR TITLE
Use ShellExecute rather than cmd.exe on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ documentation = "http://byron.github.io/open-rs"
 test = false
 doc = false
 name = "open"
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["shellapi"] }


### PR DESCRIPTION
The code is adapted from rustup. Using ShellExecute is more efficient
and allows much better error handling. It also avoids some bugs, which
is the reason rustup switched to using this method.

Fixes #16