### PR TITLE
chore: Include README/LICENSE into a release tarball

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 description = "Open a path or URL using the program configured on the system"
 repository = "https://github.com/Byron/open-rs"
 keywords = ["open", "xdg-open", "start", "launch"]
-include = ["src/**/*.rs", "Cargo.toml"]
+include = ["src/**/*.rs", "Cargo.toml", "*.md"]
 
 [[bin]]
 test = false


### PR DESCRIPTION
We can't update to the latest version due to this in the Fedora.