### PR TITLE
Revert usage of Command::new(explorer) to ShellExecuteW

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ mod windows {
     use std::ffi::OsStr;
     use std::io;
     use std::os::windows::{ffi::OsStrExt, process::ExitStatusExt};
-    use std::process::{Command, ExitStatus};
+    use std::process::ExitStatus;
     use std::ptr;
 
     use winapi::ctypes::c_int;


### PR DESCRIPTION
This restores the previous behavior on windows, and sticks to the recommended way of opening files on windows. 