### PR TITLE
Handle unsuccessful exit status in main.rs.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,14 +12,14 @@ fn main() {
     match open::that(&path_or_url) {
         Ok(status) if status.success() => (),
         Ok(status) => match status.code() {
-            Some(code) => open_error(code, &path_or_url, &format!("error code: {}", code)),
-            None => open_error(3, &path_or_url, "error unknown"),
+            Some(code) => print_error_and_exit(code, &path_or_url, &format!("error code: {}", code)),
+            None => print_error_and_exit(3, &path_or_url, "error unknown"),
         },
-        Err(err) => open_error(3, &path_or_url, &err.to_string()),
+        Err(err) => print_error_and_exit(3, &path_or_url, &err.to_string()),
     }
 }
 
-fn open_error(code: i32, path: &str, error_message: &str) {
+fn print_error_and_exit(code: i32, path: &str, error_message: &str) -> ! {
     eprintln!(
         "An error occurred when opening '{}': {}",
         path, error_message

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,9 @@ fn main() {
     match open::that(&path_or_url) {
         Ok(status) if status.success() => (),
         Ok(status) => match status.code() {
-            Some(code) => print_error_and_exit(code, &path_or_url, &format!("error code: {}", code)),
+            Some(code) => {
+                print_error_and_exit(code, &path_or_url, &format!("error code: {}", code))
+            }
             None => print_error_and_exit(3, &path_or_url, "error unknown"),
         },
         Err(err) => print_error_and_exit(3, &path_or_url, &err.to_string()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,28 +1,28 @@
-extern crate open;
-
-use std::{
-    env,
-    io::{stderr, Write},
-    process,
-};
+use std::{env, process};
 
 fn main() {
     let path_or_url = match env::args().nth(1) {
         Some(arg) => arg,
         None => {
-            writeln!(stderr(), "usage: open <path-or-url>").ok();
+            eprintln!("usage: open <path-or-url>");
             process::exit(1);
         }
     };
 
-    if let Err(err) = open::that(&path_or_url) {
-        writeln!(
-            stderr(),
-            "An error occourred when opening '{}': {}",
-            path_or_url,
-            err
-        )
-        .ok();
-        process::exit(3);
+    match open::that(&path_or_url) {
+        Ok(status) if status.success() => (),
+        Ok(status) => match status.code() {
+            Some(code) => open_error(code, &path_or_url, &format!("error code: {}", code)),
+            None => open_error(3, &path_or_url, "error unknown"),
+        },
+        Err(err) => open_error(3, &path_or_url, &err.to_string()),
     }
+}
+
+fn open_error(code: i32, path: &str, error_message: &str) {
+    eprintln!(
+        "An error occurred when opening '{}': {}",
+        path, error_message
+    );
+    process::exit(code);
 }


### PR DESCRIPTION
It may be better to encode an unsuccessful exit status in the `Err` variant instead of within the `Ok` variant. `io::Result<ExitStatus>` can be changed to `io::Result<()>` with an `io::Error` being created from `ExitStatus`. Another option is to create a custom error type. Most code, including `main.rs`, only checks the `Err` variant, assuming `Ok` was successful.

I can work on this change in another pull request if desired. This would be a breaking change but I think would result in more idiomatic code.