### PR TITLE
Improve support for wsl.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ name = "open"
 winapi = { version = "0.3", features = ["shellapi"] }
 
 [target.'cfg(all(unix, not(macos)))'.dependencies]
-which = "4"
+pathdiff = "0.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,7 @@ mod unix {
 
         unsuccessful
             .or(error)
-            .unwrap_or_else(|| Err(io::Error::from(io::ErrorKind::Other)))
+            .expect("successful cases don't get here")
     }
 
     pub fn with<T: AsRef<OsStr> + Sized>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,7 +283,10 @@ mod unix {
             .unwrap_or_else(|| Err(io::Error::from(io::ErrorKind::Other)))
     }
 
-    pub fn with<T: AsRef<OsStr> + Sized>(path: T, app: impl Into<String>) -> io::Result<ExitStatus> {
+    pub fn with<T: AsRef<OsStr> + Sized>(
+        path: T,
+        app: impl Into<String>,
+    ) -> io::Result<ExitStatus> {
         Command::new(app.into()).arg(path.as_ref()).spawn()?.wait()
     }
 


### PR DESCRIPTION
The default Ubuntu installation for wsl contains the `gio` command but no applications are registered to handle files. With the current implementation `wslview` is never called if another command exists but fails to open the file. This pull request modifies `that()` to loop over every open handler until one reports a successful exit status.

To work around a bug in `wslview` the `wsl_path()` function is introduced to convert an absolute path into a relative path. If `wslview` fails to find the path, which occurs with absolute paths or non-existent files it erroneously returns a successful exit status.

The `which` dependency was removed but the `pathdiff` dependency was added.
