### PR TITLE
Add empty rustfmt.toml file to enforce defaults.

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+# Rustfmt Configuration.
+
+## Empty to enforce all defaults.
+## Overrides configuration from parent directory, home directory, and global config directory.


### PR DESCRIPTION
Add empty `rustfmt.toml` file to enforce defaults with overrides configuration from parent directory, home directory, and global config directory.