### PR TITLE
Encode unsuccessful exit status in Err.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,21 +10,10 @@ fn main() {
     };
 
     match open::that(&path_or_url) {
-        Ok(status) if status.success() => (),
-        Ok(status) => match status.code() {
-            Some(code) => {
-                print_error_and_exit(code, &path_or_url, &format!("error code: {}", code))
-            }
-            None => print_error_and_exit(3, &path_or_url, "error unknown"),
-        },
-        Err(err) => print_error_and_exit(3, &path_or_url, &err.to_string()),
+        Ok(()) => println!("Opened '{}' successfully.", path_or_url),
+        Err(err) => {
+            eprintln!("An error occurred when opening '{}': {}", path_or_url, err);
+            process::exit(3);
+        }
     }
-}
-
-fn print_error_and_exit(code: i32, path: &str, error_message: &str) -> ! {
-    eprintln!(
-        "An error occurred when opening '{}': {}",
-        path, error_message
-    );
-    process::exit(code);
 }


### PR DESCRIPTION
Change result from `io::Result<ExitStatus>` to `io::Result<()>`. Commands that exit with a successful exit status result in `Ok`, otherwise an `Err` variant is created.

Error information is gathered from the stderr channel of the process using a single read operation. This prevents the child process from keeping the main process alive if stderr is kept open.

## Notes

`wslview` always reports a 0 exit status, even if the path does not exist, which results in false positives. The stderr channel is written to but ignored in this implementation because of the successful exit status. Other programs write to stderr as part of normal operation. Firefox on Linux never seems to be able to load all the modules it wants to, so it writes to stderr but successfully opens. The only way to avoid these false positives is to special case wsl or for `wslview` to fix the unsuccessful exit status bug. This is only a minor problem and can mostly be ignored.