### PR TITLE
Use full path for `open` command on macOS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,14 +272,14 @@ mod macos {
     use crate::{CommandExt, IntoResult, Result};
 
     pub fn that<T: AsRef<OsStr> + Sized>(path: T) -> Result {
-        Command::new("open")
+        Command::new("/usr/bin/open")
             .arg(path.as_ref())
             .output_stderr()
             .into_result()
     }
 
     pub fn with<T: AsRef<OsStr> + Sized>(path: T, app: impl Into<String>) -> Result {
-        Command::new("open")
+        Command::new("/usr/bin/open")
             .arg(path.as_ref())
             .arg("-a")
             .arg(app.into())


### PR DESCRIPTION
This patch uses `/usr/bin/open` instead of `open` command to ensure to run the expected command. With current implementation, an unexpected command may be run when users overwrite `open` command in their environments.