### PR TITLE
On Windows, add double quotes to path.

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,4 +1,4 @@
-use std::{ffi::OsStr, io, os::windows::ffi::OsStrExt, ptr};
+use std::{ffi::{OsStr,OsString}, io, os::windows::ffi::OsStrExt, ptr};
 
 use std::os::raw::c_int;
 use windows_sys::Win32::UI::Shell::ShellExecuteW;
@@ -6,7 +6,13 @@ use windows_sys::Win32::UI::Shell::ShellExecuteW;
 use crate::IntoResult;
 
 fn convert_path(path: &OsStr) -> io::Result<Vec<u16>> {
-    let mut maybe_result: Vec<_> = path.encode_wide().collect();
+    // Surround path with double quotes "" to handle spaces in path.
+    let mut quoted_path = OsString::with_capacity(path.len());
+    quoted_path.push("\"");
+    quoted_path.push(&path);
+    quoted_path.push("\"");
+
+    let mut maybe_result: Vec<_> = quoted_path.encode_wide().collect();
     if maybe_result.iter().any(|&u| u == 0) {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,4 +1,9 @@
-use std::{ffi::{OsStr,OsString}, io, os::windows::ffi::OsStrExt, ptr};
+use std::{
+    ffi::{OsStr, OsString},
+    io,
+    os::windows::ffi::OsStrExt,
+    ptr,
+};
 
 use std::os::raw::c_int;
 use windows_sys::Win32::UI::Shell::ShellExecuteW;
@@ -6,21 +11,22 @@ use windows_sys::Win32::UI::Shell::ShellExecuteW;
 use crate::IntoResult;
 
 fn convert_path(path: &OsStr) -> io::Result<Vec<u16>> {
-    // Surround path with double quotes "" to handle spaces in path.
     let mut quoted_path = OsString::with_capacity(path.len());
+
+    // Surround path with double quotes "" to handle spaces in path.
     quoted_path.push("\"");
     quoted_path.push(&path);
     quoted_path.push("\"");
 
-    let mut maybe_result: Vec<_> = quoted_path.encode_wide().collect();
-    if maybe_result.iter().any(|&u| u == 0) {
+    let mut wide_chars: Vec<_> = quoted_path.encode_wide().collect();
+    if wide_chars.iter().any(|&u| u == 0) {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "path contains NUL byte(s)",
         ));
     }
-    maybe_result.push(0);
-    Ok(maybe_result)
+    wide_chars.push(0);
+    Ok(wide_chars)
 }
 
 pub fn that<T: AsRef<OsStr>>(path: T) -> io::Result<()> {


### PR DESCRIPTION
Related to issue #53. This adds double quotes (`" "`) around the path to the opened file.