### PR TITLE
Upgrade to windows-sys v0.42.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ doc = false
 name = "open"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.36", features = ["Win32_UI_Shell", "Win32_Foundation"] }
+windows-sys = { version = "0.42", features = ["Win32_UI_Shell", "Win32_Foundation"] }
 
 [target.'cfg(all(unix, not(macos)))'.dependencies]
 pathdiff = "0.2.0"


### PR DESCRIPTION
To avoid duplicate dependencies in downstream crates.