### PR TITLE
open::with args

### DIFF
--- a/examples/with.rs
+++ b/examples/with.rs
@@ -1,0 +1,21 @@
+use std::{env, process};
+
+fn main() {
+    let args = env::args().skip(1).collect::<Vec<String>>();
+    let (path_or_url, app) = match args.as_slice() {
+        [path_or_url, app @ ..] => (path_or_url, app),
+        _ => {
+            eprintln!("usage: with <path-or-url> <app> [args...]");
+            process::exit(1);
+        }
+    };
+
+    let args = app.join(" ");
+    match open::with(path_or_url, args) {
+        Ok(()) => println!("Opened '{}' successfully.", path_or_url),
+        Err(err) => {
+            eprintln!("An error occurred when opening '{}': {}", path_or_url, err);
+            process::exit(3);
+        }
+    }
+}

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::VecDeque,
     env,
     ffi::{OsStr, OsString},
     io,
@@ -44,7 +45,15 @@ pub fn that<T: AsRef<OsStr>>(path: T) -> io::Result<()> {
 }
 
 pub fn with<T: AsRef<OsStr>>(path: T, app: impl Into<String>) -> io::Result<()> {
-    Command::new(app.into())
+    let app: String = app.into();
+    let mut args = app.split_whitespace().collect::<VecDeque<&str>>();
+    let (cmd, args) = args
+        .pop_front()
+        .map(move |cmd| (cmd, args))
+        .unwrap_or((&app, VecDeque::from([])));
+
+    Command::new(cmd)
+        .args(args)
         .arg(path.as_ref())
         .status_without_output()
         .into_result()


### PR DESCRIPTION
`open::with(path, "firefox --new-window --more-flags")` primitively passes the args to `Command`. Primitively, because `String::split_whitespace` might not be good enough. There is a crate
[shell-words](https://crates.io/crates/shell-words) that would do the right thing, but I don't want to bring in a dependency unless asked.

Related to #42, but more primitive and only for `unix` - no idea about win/mac.