### PR TITLE
feat: add commands function

### DIFF
--- a/src/haiku.rs
+++ b/src/haiku.rs
@@ -2,11 +2,14 @@ use std::{ffi::OsStr, io, process::Command};
 
 use crate::{CommandExt, IntoResult};
 
+pub fn command<T: AsRef<OsStr>>(path: T) -> Command {
+    let mut cmd = Command::new("/bin/open");
+    cmd.arg(path.as_ref());
+    cmd
+}
+
 pub fn that<T: AsRef<OsStr>>(path: T) -> io::Result<()> {
-    Command::new("/bin/open")
-        .arg(path.as_ref())
-        .status_without_output()
-        .into_result()
+    command(path).status_without_output().into_result()
 }
 
 pub fn with<T: AsRef<OsStr>>(path: T, app: impl Into<String>) -> io::Result<()> {

--- a/src/haiku.rs
+++ b/src/haiku.rs
@@ -2,19 +2,24 @@ use std::{ffi::OsStr, io, process::Command};
 
 use crate::{CommandExt, IntoResult};
 
-pub fn command<T: AsRef<OsStr>>(path: T) -> Command {
-    let mut cmd = Command::new("/bin/open");
-    cmd.arg(path.as_ref());
-    cmd
-}
-
 pub fn that<T: AsRef<OsStr>>(path: T) -> io::Result<()> {
-    command(path).status_without_output().into_result()
+    Command::new("/bin/open")
+        .arg(path.as_ref())
+        .without_io()
+        .status()
+        .into_result()
 }
 
 pub fn with<T: AsRef<OsStr>>(path: T, app: impl Into<String>) -> io::Result<()> {
     Command::new(app.into())
         .arg(path.as_ref())
-        .status_without_output()
+        .without_io()
+        .status()
         .into_result()
+}
+
+pub fn commands<T: AsRef<OsStr>>(path: T) -> impl Iterator<Item = Command> {
+    let mut cmd = Command::new("/bin/open");
+    cmd.arg(path.as_ref());
+    Some(cmd).into_iter()
 }

--- a/src/ios.rs
+++ b/src/ios.rs
@@ -2,12 +2,14 @@ use std::{ffi::OsStr, io, process::Command};
 
 use crate::{CommandExt, IntoResult};
 
+pub fn command<T: AsRef<OsStr>>(path: T) -> Command {
+    let mut cmd = Command::new("uiopen");
+    cmd.arg("--url").arg(path.as_ref());
+    cmd
+}
+
 pub fn that<T: AsRef<OsStr>>(path: T) -> io::Result<()> {
-    Command::new("uiopen")
-        .arg("--url")
-        .arg(path.as_ref())
-        .status_without_output()
-        .into_result()
+    command(path).status_without_output().into_result()
 }
 
 pub fn with<T: AsRef<OsStr>>(path: T, app: impl Into<String>) -> io::Result<()> {

--- a/src/ios.rs
+++ b/src/ios.rs
@@ -2,14 +2,13 @@ use std::{ffi::OsStr, io, process::Command};
 
 use crate::{CommandExt, IntoResult};
 
-pub fn command<T: AsRef<OsStr>>(path: T) -> Command {
-    let mut cmd = Command::new("uiopen");
-    cmd.arg("--url").arg(path.as_ref());
-    cmd
-}
-
 pub fn that<T: AsRef<OsStr>>(path: T) -> io::Result<()> {
-    command(path).status_without_output().into_result()
+    Command::new("uiopen")
+        .arg("--url")
+        .arg(path.as_ref())
+        .without_io()
+        .status()
+        .into_result()
 }
 
 pub fn with<T: AsRef<OsStr>>(path: T, app: impl Into<String>) -> io::Result<()> {
@@ -18,6 +17,13 @@ pub fn with<T: AsRef<OsStr>>(path: T, app: impl Into<String>) -> io::Result<()> 
         .arg(path.as_ref())
         .arg("--bundleid")
         .arg(app.into())
-        .status_without_output()
+        .without_io()
+        .status()
         .into_result()
+}
+
+pub fn commands<T: AsRef<OsStr>>(path: T) -> impl Iterator<Item = Command> {
+    let mut cmd = Command::new("uiopen");
+    cmd.arg("--url").arg(path.as_ref());
+    Some(cmd).into_iter()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,12 @@
 //! open::with("http://rust-lang.org", "firefox").unwrap();
 //! ```
 //!
+//! Or obtain the command without running it.
+//!
+//! ```no_run
+//! let cmd = open::command("http://rust-lang.org");
+//! ```
+//!
 //! # Notes
 //!
 //! ## Nonblocking operation
@@ -129,6 +135,18 @@ pub fn that<T: AsRef<OsStr>>(path: T) -> io::Result<()> {
 /// handle errors differently it is recommend to not match on a certain error.
 pub fn with<T: AsRef<OsStr>>(path: T, app: impl Into<String>) -> io::Result<()> {
     os::with(path, app)
+}
+
+/// Get command that opens path with the default application.
+///
+/// # Examples
+///
+/// ```no_run
+/// let path = "http://rust-lang.org";
+/// let cmd = open::command(path);
+/// ```
+pub fn command<'a, T: AsRef<OsStr>>(path: T) -> Command {
+    os::command(path)
 }
 
 /// Open path with the default application in a new thread.

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -2,14 +2,12 @@ use std::{ffi::OsStr, io, process::Command};
 
 use crate::{CommandExt, IntoResult};
 
-pub fn command<T: AsRef<OsStr>>(path: T) -> Command {
-    let mut cmd = Command::new("/usr/bin/open");
-    cmd.arg(path.as_ref());
-    cmd
-}
-
 pub fn that<T: AsRef<OsStr>>(path: T) -> io::Result<()> {
-    command(path).status_without_output().into_result()
+    Command::new("/usr/bin/open")
+        .arg(path.as_ref())
+        .without_io()
+        .status()
+        .into_result()
 }
 
 pub fn with<T: AsRef<OsStr>>(path: T, app: impl Into<String>) -> io::Result<()> {
@@ -17,6 +15,13 @@ pub fn with<T: AsRef<OsStr>>(path: T, app: impl Into<String>) -> io::Result<()> 
         .arg(path.as_ref())
         .arg("-a")
         .arg(app.into())
-        .status_without_output()
+        .without_io()
+        .status()
         .into_result()
+}
+
+pub fn commands<T: AsRef<OsStr>>(path: T) -> impl Iterator<Item = Command> {
+    let mut cmd = Command::new("/usr/bin/open");
+    cmd.arg(path.as_ref());
+    Some(cmd).into_iter()
 }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -2,11 +2,14 @@ use std::{ffi::OsStr, io, process::Command};
 
 use crate::{CommandExt, IntoResult};
 
+pub fn command<T: AsRef<OsStr>>(path: T) -> Command {
+    let mut cmd = Command::new("/usr/bin/open");
+    cmd.arg(path.as_ref());
+    cmd
+}
+
 pub fn that<T: AsRef<OsStr>>(path: T) -> io::Result<()> {
-    Command::new("/usr/bin/open")
-        .arg(path.as_ref())
-        .status_without_output()
-        .into_result()
+    command(path).status_without_output().into_result()
 }
 
 pub fn with<T: AsRef<OsStr>>(path: T, app: impl Into<String>) -> io::Result<()> {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -11,17 +11,15 @@ use crate::{CommandExt, IntoResult};
 pub fn command<T: AsRef<OsStr>>(path: T) -> Command {
     let path = path.as_ref();
     let open_handlers = [
-        ("xdg-open", &["--version"], &[path] as &[_]),
-        ("gio", &["version"], &[OsStr::new("open"), path]),
-        ("gnome-open", &["--version"], &[path]),
-        ("kde-open", &["--version"], &[path]),
-        ("wslview", &["--version"], &[&wsl_path(path)]),
+        ("xdg-open", &[path] as &[_]),
+        ("gio", &[OsStr::new("open"), path]),
+        ("gnome-open", &[path]),
+        ("kde-open", &[path]),
+        ("wslview", &[&wsl_path(path)]),
     ];
 
-    for (command, check_args, args) in &open_handlers {
-        let result = Command::new(command)
-            .args(*check_args)
-            .status_without_output();
+    for (command, args) in &open_handlers {
+        let result = Command::new(command).status_without_output();
 
         if let Ok(status) = result {
             if status.success() {
@@ -33,7 +31,7 @@ pub fn command<T: AsRef<OsStr>>(path: T) -> Command {
     }
 
     // fallback to xdg-open
-    let (command, _, args) = &open_handlers[0];
+    let (command, args) = &open_handlers[0];
     let mut cmd = Command::new(command);
     cmd.args(*args);
     cmd

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,5 +1,7 @@
 use std::{ffi::OsStr, io, process::Command};
 
+use crate::{CommandExt, IntoResult};
+
 pub fn command<T: AsRef<OsStr>>(path: T) -> Command {
     let mut cmd = Command::new("cmd");
     cmd.arg("/c").arg("start").arg(path.as_ref());

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -2,14 +2,13 @@ use std::{ffi::OsStr, io, process::Command};
 
 use crate::{CommandExt, IntoResult};
 
-pub fn command<T: AsRef<OsStr>>(path: T) -> Command {
-    let mut cmd = Command::new("cmd");
-    cmd.arg("/c").arg("start").arg(path.as_ref());
-    cmd
-}
-
 pub fn that<T: AsRef<OsStr>>(path: T) -> io::Result<()> {
-    command(path).status_without_output().into_result()
+    Command::new("cmd")
+        .arg("/c")
+        .arg("start")
+        .arg(path.as_ref())
+        .without_io()
+        .status()
 }
 
 pub fn with<T: AsRef<OsStr>>(path: T, app: impl Into<String>) -> io::Result<()> {
@@ -17,6 +16,13 @@ pub fn with<T: AsRef<OsStr>>(path: T, app: impl Into<String>) -> io::Result<()> 
         .arg("/c")
         .arg(app.into())
         .arg(path.as_ref())
-        .status_without_output()
+        .without_io()
+        .status()
         .into_result()
+}
+
+pub fn commands<T: AsRef<OsStr>>(path: T) -> impl Iterator<Item = Command> {
+    let mut cmd = Command::new("cmd");
+    cmd.arg("/c").arg("start").arg(path.as_ref());
+    Some(cmd).into_iter()
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,18 +1,17 @@
-use std::{ffi::OsStr, io};
+use std::{ffi::OsStr, io, process::Command};
 
-use crate::{CommandExt, IntoResult};
+pub fn command<T: AsRef<OsStr>>(path: T) -> Command {
+    let mut cmd = Command::new("cmd");
+    cmd.arg("/c").arg("start").arg(path.as_ref());
+    cmd
+}
 
 pub fn that<T: AsRef<OsStr>>(path: T) -> io::Result<()> {
-    std::process::Command::new("cmd")
-        .arg("/c")
-        .arg("start")
-        .arg(path.as_ref())
-        .status_without_output()
-        .into_result()
+    command(path).status_without_output().into_result()
 }
 
 pub fn with<T: AsRef<OsStr>>(path: T, app: impl Into<String>) -> io::Result<()> {
-    std::process::Command::new("cmd")
+    Command::new("cmd")
         .arg("/c")
         .arg(app.into())
         .arg(path.as_ref())


### PR DESCRIPTION
Adds new `commands` function that returns iterator over `std::Command`. This exposes the commands used by `that` to the callee so that they are able to run the command on their side.

Related: https://github.com/Byron/open-rs/pull/63
Related: https://github.com/helix-editor/helix/pull/5820