### PR TITLE
Fix Windows URL encoding for multiple query params

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,13 +1,31 @@
-use std::{ffi::OsStr, process::Command};
+use std::{
+    ffi::{OsStr, OsString},
+    process::Command,
+};
+
+use std::os::windows::process::CommandExt;
 
 pub fn commands<T: AsRef<OsStr>>(path: T) -> Vec<Command> {
     let mut cmd = Command::new("cmd");
-    cmd.arg("/c").arg("start").arg(path.as_ref());
+    cmd.arg("/c")
+        .arg("start")
+        .raw_arg("\"\"")
+        .raw_arg(wrap_in_quotes(path.as_ref()));
     vec![cmd]
 }
 
 pub fn with_command<T: AsRef<OsStr>>(path: T, app: impl Into<String>) -> Command {
     let mut cmd = Command::new("cmd");
-    cmd.arg("/c").arg(app.into()).arg(path.as_ref());
+    cmd.arg("/c")
+        .raw_arg(app.into())
+        .raw_arg(wrap_in_quotes(path.as_ref()));
     cmd
+}
+
+fn wrap_in_quotes<T: AsRef<OsStr>>(path: T) -> OsString {
+    let mut result = OsString::from("\"");
+    result.push(path);
+    result.push("\"");
+
+    result
 }


### PR DESCRIPTION
Previously, passing a URL with multiple query parameters on Windows would result in improper escaping, causing unexpected behavior when using it with "cmd /c". This commit addresses this issue by properly escaping all query parameters in the URL. Now, URLs with multiple query parameters are handled correctly on Windows.

See also:
* https://doc.rust-lang.org/std/os/windows/process/trait.CommandExt.html#tymethod.raw_arg
* https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/cmd
* https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/start

Related #67 