### PR TITLE
Use `wslview` on WSL even when `gio` is installed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ name = "open"
 
 [target.'cfg(all(unix, not(macos)))'.dependencies]
 pathdiff = "0.2.0"
+
+[dependencies]
+is-wsl = "0.4.0"

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Borrow,
     env,
     ffi::{OsStr, OsString},
     path::{Path, PathBuf},
@@ -8,11 +9,11 @@ use std::{
 pub fn commands<T: AsRef<OsStr>>(path: T) -> Vec<Command> {
     let path = path.as_ref();
     [
+        ("wslview", &[wsl_path(path).borrow()] as &[_]),
         ("xdg-open", &[path] as &[_]),
         ("gio", &[OsStr::new("open"), path]),
         ("gnome-open", &[path]),
         ("kde-open", &[path]),
-        ("wslview", &[&wsl_path(path)]),
     ]
     .iter()
     .map(|(command, args)| {


### PR DESCRIPTION
This PR fixes a bug I've been experiencing on WSL.

I have [`gio`](https://en.wikipedia.org/wiki/GIO_(software)) installed in my WSL environment because it comes bundled with [`glib`](https://en.wikipedia.org/wiki/GLib). Because of this, `open-rs` attempts to use `gio` and fails:

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Custom { kind: Other, error: "Launcher \"gio\" \"open\" \"https://google.com\" failed with ExitStatus(unix_wait_status(512))" }', examples/website.rs:4:38
stack backtrace:
   0: rust_begin_unwind
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/std/src/panicking.rs:575:5
   1: core::panicking::panic_fmt
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/core/src/panicking.rs:65:14
   2: core::result::unwrap_failed
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/core/src/result.rs:1791:5
   3: core::result::Result<T,E>::unwrap
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/core/src/result.rs:1113:23
   4: website::main
             at ./examples/website.rs:4:5
   5: core::ops::function::FnOnce::call_once
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/core/src/ops/function.rs:251:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

To solve this, this PR just reorders the launchers used on unix so that `wslview` is attempted first. I think this is desirable behaviour because if `wslview` is present we're almost certainly in WSL.

If you foresee any problems with this approach, I could rewrite this to check whether we're in WSL before attempting to use `wslview`.