### PR TITLE
Fix version in readme document

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ xdg-open <path-or-url> || gio open <path-or-url> || gnome-open <path-or-url> |
 Add this to your Cargo.toml
 ```toml
 [dependencies]
-open = "3"
+open = "4"
 ```
 …and open something using…
 ```Rust


### PR DESCRIPTION
I found readme document is not following the new major version. This PR fixes it.