### PR TITLE
explorer as alternative launcher on windows

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -9,12 +9,21 @@ const CREATE_NO_WINDOW: u32 = 0x08000000;
 
 pub fn commands<T: AsRef<OsStr>>(path: T) -> Vec<Command> {
     let mut cmd = Command::new("cmd");
+    let path = path.as_ref();
     cmd.arg("/c")
         .arg("start")
         .raw_arg("\"\"")
         .raw_arg(wrap_in_quotes(path))
         .creation_flags(CREATE_NO_WINDOW);
-    vec![cmd]
+    // in certain situations the above doesn't work, so we try to use explorer as mediator.
+    // See https://github.com/Byron/open-rs/issues/73 for details.
+    let mut alt_cmd = Command::new("cmd");
+    alt_cmd
+        .arg("/c")
+        .arg("explorer")
+        .raw_arg(wrap_in_quotes(path))
+        .creation_flags(CREATE_NO_WINDOW);
+    vec![cmd, alt_cmd]
 }
 
 pub fn with_command<T: AsRef<OsStr>>(path: T, app: impl Into<String>) -> Command {


### PR DESCRIPTION
It seems in VSCode launching with `cmd` alone doesn't work, but using `explorer` as mediator
does the trick.
Now on windows there is an additional launcher to try.
