### PR TITLE
Fix open::with() on Windows. (#80)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,9 +9,19 @@ fn main() {
         }
     };
 
+    #[cfg(not(windows))]
     let result = match std::env::var("OPEN_WITH").ok() {
         Some(program) => open::with(&path_or_url, program),
         None => open::that(&path_or_url),
+    };
+
+    #[cfg(windows)]
+    let result = match env::args().nth(2) {
+        Some(arg) if arg == "--with" || arg == "-w" => match env::args().nth(3) {
+            Some(program) => open::with(&path_or_url, program),
+            None => open::that(&path_or_url),
+        },
+        _ => open::that(&path_or_url),
     };
 
     match result {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,34 +1,23 @@
-use std::{env, process};
+use std::env;
 
-fn main() {
-    let path_or_url = match env::args().nth(1) {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = env::args();
+    let path_or_url = match args.nth(1) {
         Some(arg) => arg,
-        None => {
-            eprintln!("usage: open <path-or-url>");
-            process::exit(1);
-        }
+        None => return Err("usage: open <path-or-url> [--with|-w program]".into()),
     };
 
-    #[cfg(not(windows))]
-    let result = match std::env::var("OPEN_WITH").ok() {
-        Some(program) => open::with(&path_or_url, program),
+    match args.next() {
+        Some(arg) if arg == "--with" || arg == "-w" => {
+            let program = args
+                .next()
+                .ok_or("--with must be followed by the program to use for opening")?;
+            open::with(&path_or_url, program)
+        }
+        Some(arg) => return Err(format!("Argument '{arg}' is invalid").into()),
         None => open::that(&path_or_url),
-    };
+    }?;
 
-    #[cfg(windows)]
-    let result = match env::args().nth(2) {
-        Some(arg) if arg == "--with" || arg == "-w" => match env::args().nth(3) {
-            Some(program) => open::with(&path_or_url, program),
-            None => open::that(&path_or_url),
-        },
-        _ => open::that(&path_or_url),
-    };
-
-    match result {
-        Ok(()) => println!("Opened '{}' successfully.", path_or_url),
-        Err(err) => {
-            eprintln!("An error occurred when opening '{}': {}", path_or_url, err);
-            process::exit(3);
-        }
-    }
+    println!("Opened '{}' successfully.", path_or_url);
+    Ok(())
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -20,6 +20,8 @@ pub fn commands<T: AsRef<OsStr>>(path: T) -> Vec<Command> {
 pub fn with_command<T: AsRef<OsStr>>(path: T, app: impl Into<String>) -> Command {
     let mut cmd = Command::new("cmd");
     cmd.arg("/c")
+        .arg("start")
+        .raw_arg("\"\"")
         .raw_arg(app.into())
         .raw_arg(wrap_in_quotes(path))
         .creation_flags(CREATE_NO_WINDOW);


### PR DESCRIPTION
On Windows OS, my colleagues and I conducted tests and found that:

- `cmd /c app` command can't open apps which are not in the env variables.
- However, `cmd /c start app` can open all apps exist in registry path `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths`. This is why I added `start` to open::with() under the Windows branch. And I recommend adding the registry address that represents the available scope to the doc or README (on Mac and Linux it may be other files), so that developers can quickly determine appnames available.
![image](https://github.com/Byron/open-rs/assets/67895752/453ddb7c-2044-4c13-9daf-b552daa9c44d)

- Commands like `cmd /c "C:\app.exe"` can also open the application, but `cmd /c start "C:\app.exe"` does not work. Finally I found that `start "" "C:\app.exe"` is effective which "" is said to open a new window, and `start "" app` also works. It is safe and consistent with the previous changes to open::that(), so I added `""` as an arg.
- To avoid the previous issue, I guess some people might pass `start chrome` as the second function param. After adding two args, it can still open the app but will also open a new cmd window, should this situation be taken into consideration?

At last, I modified the test code in main.rs. On Windows, you can call open::with() by using `open.exe path -w app` without specifying an env variable.