### PR TITLE
Wrap provided app in quotes on Windows

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -22,7 +22,7 @@ pub fn with_command<T: AsRef<OsStr>>(path: T, app: impl Into<String>) -> Command
     cmd.arg("/c")
         .arg("start")
         .raw_arg("\"\"")
-        .raw_arg(app.into())
+        .raw_arg(wrap_in_quotes(app.into()))
         .raw_arg(wrap_in_quotes(path))
         .creation_flags(CREATE_NO_WINDOW);
     cmd


### PR DESCRIPTION
When providing an app to open a file, if the user provides a path to the app with a space, Windows attempts to split the path at the space, resulting in unintended behavior. 

This PR fixes this issue by wrapping the provided `app` in double quotes, the same fix applied to resolve a similar issue with file paths in #54.

Further documentation is in #85.