### PR TITLE
redox: use PATH to find launcher

### DIFF
--- a/src/redox.rs
+++ b/src/redox.rs
@@ -1,7 +1,7 @@
 use std::{ffi::OsStr, process::Command};
 
 pub fn commands<T: AsRef<OsStr>>(path: T) -> Vec<Command> {
-    let mut cmd = Command::new("/ui/bin/launcher");
+    let mut cmd = Command::new("launcher");
     cmd.arg(path.as_ref());
     vec![cmd]
 }


### PR DESCRIPTION
Redox has moved the launcher from /ui/bin to /usr/bin. Just use the PATH to locate it, so any future changes in location don't break this crate.