### PR TITLE
Add AIX support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ name = "open"
 [target.'cfg(all(unix, not(macos)))'.dependencies]
 pathdiff = "0.2.0"
 
-[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd", target_os = "illumos", target_os = "solaris" ))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd", target_os = "illumos", target_os = "solaris", target_os = "aix" ))'.dependencies]
 is-wsl = "0.4.0"
 
 [target."cfg(unix)".dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,8 @@ use redox as os;
     target_os = "netbsd",
     target_os = "openbsd",
     target_os = "illumos",
-    target_os = "solaris"
+    target_os = "solaris",
+    target_os = "aix"
 ))]
 use unix as os;
 
@@ -110,7 +111,8 @@ use unix as os;
     target_os = "macos",
     target_os = "windows",
     target_os = "haiku",
-    target_os = "redox"
+    target_os = "redox",
+    target_os = "aix"
 )))]
 compile_error!("open is not supported on this platform");
 
@@ -373,6 +375,7 @@ mod redox;
     target_os = "netbsd",
     target_os = "openbsd",
     target_os = "illumos",
-    target_os = "solaris"
+    target_os = "solaris",
+    target_os = "aix"
 ))]
 mod unix;


### PR DESCRIPTION
This crate is essential to build typst on AIX. Add AIX support for it.