### PR TITLE
fix(windows): fix `that_detached` for UNC path of a directory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.62"
 ##
 ## There may be other side-effects that when comparing to the command-based
 ## opening of paths, which is why this feature is opt-in.
-shellexecute-on-windows = []
+shellexecute-on-windows = ["dep:dunce"]
 
 [[bin]]
 test = false
@@ -35,3 +35,6 @@ is-wsl = "0.4.0"
 
 [target."cfg(unix)".dependencies]
 libc = "0.2"
+
+[target."cfg(windows)".dependencies]
+dunce = { version = "1", optional = true }


### PR DESCRIPTION
closes #106

Strip UNC (`\?\\`) prefixes when opening directories using the `dunce` crate.

This PR also falls back to `ShellExecuteExW` in the rare case that `SHOpenFolderAndSelectItems` might fail, very unlikely but still good to do IMO.

However, I should note that `SHOpenFolderAndSelectItems` in some cases, instead of returning an error, it falls back to opening a default directory which is usually the `Documents` folder, this PR does not fix that as the Windows API doesn't return an error for it.