### PR TITLE
feat: support BROWSER env var in Linux

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/rust
+{
+    "name": "Rust",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "image": "mcr.microsoft.com/devcontainers/rust:1-1-bullseye",
+    // Configure tool-specific properties.
+    "customizations": {
+        "codespaces": {
+            "openFiles": [
+                "README.md"
+            ]
+        },
+        "vscode": {
+            "extensions": [
+                "rust-lang.rust-analyzer"
+            ]
+        }
+    }
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,9 +77,7 @@
 //!
 // On a console, without a window manager, results will likely be poor. The openers expect to be able to open in a new or existing window, something that consoles lack.
 //!
-//! On Windows WSL, `wslview` is tried first, then `xdg-open`. In other UNIX environments, `xdg-open` is tried first. If this fails, a sequence of other openers is tried.
-//!
-//! Currently the `BROWSER` environment variable is ignored even for `http:` and `https:` URLs unless the opener being used happens to respect it.
+//! First, `$BROWSER` is tried (if defined). On Windows WSL, `wslview` is tried next, then `xdg-open`. In other UNIX environments, `xdg-open` is tried next. If this fails, a sequence of other openers is tried.
 //!
 //! It cannot be overemphasized how fragile this all is in UNIX environments. It is common for the various MIME tables to incorrectly specify the application "owning" a given filetype.
 //! It is common for openers to behave strangely. Use with caution, as this crate merely inherits a particular platforms shortcomings.

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -7,18 +7,23 @@ use std::{
 
 pub fn commands<T: AsRef<OsStr>>(path: T) -> Vec<Command> {
     let path = path.as_ref();
-    let mut commands: Vec<(&str, Vec<&OsStr>)> = vec![];
+    let mut commands: Vec<(String, Vec<&OsStr>)> = vec![];
+
+    // Make the `$BROWSER` environment variable (if it's defined) the highest priority.
+    if let Ok(browser) = env::var("BROWSER") {
+        commands.push((browser, vec![path]));
+    }
 
     let wsl_path = wsl_path(path);
     if is_wsl::is_wsl() {
-        commands.push(("wslview", vec![&wsl_path]));
+        commands.push(("wslview".to_string(), vec![&wsl_path]));
     }
 
     commands.extend_from_slice(&[
-        ("xdg-open", vec![&path]),
-        ("gio", vec![OsStr::new("open"), path]),
-        ("gnome-open", vec![path]),
-        ("kde-open", vec![path]),
+        ("xdg-open".to_string(), vec![&path]),
+        ("gio".to_string(), vec![OsStr::new("open"), path]),
+        ("gnome-open".to_string(), vec![path]),
+        ("kde-open".to_string(), vec![path]),
     ]);
 
     commands


### PR DESCRIPTION
Per #108, this PR adds support for the `BROWSER` environment variable in Linux.

I've also added a Codespaces config file, which allowed me to test this easily in Codespaces.

Feedback is welcome!