### PR TITLE
docs: point to webbrowser crate for users that seek this specific functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ $ start <path-or-url>
 $ xdg-open <path-or-url> || gio open <path-or-url> || gnome-open <path-or-url> || kde-open <path-or-url> || wslview <path-or-url>
 ```
 
+To open a web browser, see the [webbrowser](https://docs.rs/webbrowser) crate, which offers functionality for that specific case.
+
 # Library Usage
 
 Add this to your Cargo.toml

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 //! Use this library to open a given path or URL in some application, obeying the current user's desktop configuration.
 //!
-//! It is expected that `http:` and `https:` URLs will open in a web browser, although desktop configuration may override this.
+//! It is expected that `http:` and `https:` URLs will open in a web browser, although the desktop configuration may override this.
 //! The choice of application for opening other path types is highly system-dependent.
+//! 
+//! To always open a web browser, see the [webbrowser](https://docs.rs/webbrowser) crate, which offers functionality for that specific case.
 //!
 //! # Usage
 //!


### PR DESCRIPTION
This follows up on the discussion in #109 and follows the recommendation in #8 -- for users that specifically want to open a web browser, use the webbrowser crate. For the more general case of opening a path or URL, this is the correct crate.