### PR TITLE
fix(windows): pass canonicalized path to `ILCreateFromPathW`

### DIFF
--- a/.github/workflows/cross-platform-testing.yml
+++ b/.github/workflows/cross-platform-testing.yml
@@ -35,11 +35,11 @@ jobs:
             rust: nightly
             target: x86_64-apple-darwin
           - build: win-msvc
-            os: windows-2019
+            os: windows-2022
             rust: stable
             target: x86_64-pc-windows-msvc
           - build: win-gnu
-            os: windows-2019
+            os: windows-2022
             rust: stable
             target: x86_64-pc-windows-gnu
           - build: win32-gnu


### PR DESCRIPTION
Fix https://github.com/tauri-apps/plugins-workspace/issues/3102

Use `canonicalize` instead of `simplified` here to allow mixed path seperators to work (e.g. `C:\Program Files/Some App`)

Also added a null check guard on `ILCreateFromPathW` for cases where we have reached `MAX_PATH` limit or hit other errors to prevent `SHOpenFolderAndSelectItems` from hanging

Finally added `ILFree` for the `ITEMIDLIST` returned from `ILCreateFromPathW` which I forgot to add in https://github.com/Byron/open-rs/pull/104