### PR TITLE
fix(macos): avoid double detachment to prevent silent failure

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,7 +291,16 @@ pub fn that_detached(path: impl AsRef<OsStr>) -> io::Result<()> {
 ///
 /// See documentation of [`with()`] for more details.
 pub fn with_detached<T: AsRef<OsStr>>(path: T, app: impl Into<String>) -> io::Result<()> {
-    #[cfg(any(not(feature = "shellexecute-on-windows"), not(windows)))]
+    #[cfg(target_os = "macos")]
+    {
+        let mut cmd = with_command(path, app);
+        cmd.status_without_output().into_result(&cmd)
+    }
+
+    #[cfg(all(
+        not(target_os = "macos"),
+        any(not(feature = "shellexecute-on-windows"), not(windows))
+    ))]
     {
         let mut cmd = with_command(path, app);
         cmd.spawn_detached()


### PR DESCRIPTION
On macOS, /usr/bin/open is natively detached. This commit changes with_detached to use the same logic as with() .avoid double detachment to prevent silent failure

This PR refactors the with_detached() implementation on macOS to align it with the logic of with().
Relies solely on `/usr/bin/open` for detachment after this change (Not sure if relying solely on `/usr/bin/open` is robust enough.)

related issue : #118