### PR TITLE
fix(windows): delegate to winebrowser under Wine

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -7,14 +7,41 @@ use std::os::windows::process::CommandExt;
 
 const CREATE_NO_WINDOW: u32 = 0x08000000;
 
+/// Detects if the current process is running under Wine by checking environment
+/// variables that Wine injects into guest processes.
+fn is_running_under_wine() -> bool {
+    std::env::var_os("WINEPREFIX").is_some()
+        || std::env::var_os("WINELOADER").is_some()
+        || std::env::var_os("WINEDEBUG").is_some()
+}
+
+/// Constructs a Command to invoke Wine's winebrowser utility, which forwards
+/// file/URL open requests to the host OS's default handler.
+fn winebrowser_command<T: AsRef<OsStr>>(path: T) -> Command {
+    let mut cmd = Command::new("winebrowser");
+    cmd.arg(path.as_ref());
+    // Match Windows behavior: suppress console window flash
+    cmd.creation_flags(CREATE_NO_WINDOW);
+    cmd
+}
+
 pub fn commands<T: AsRef<OsStr>>(path: T) -> Vec<Command> {
+    let mut cmds = Vec::new();
+
+    // When under Wine, try winebrowser first for seamless host integration.
+    if is_running_under_wine() {
+        cmds.push(winebrowser_command(&path));
+    }
+
     let mut cmd = Command::new("cmd");
     cmd.arg("/c")
         .arg("start")
         .raw_arg("\"\"")
-        .raw_arg(wrap_in_quotes(path))
+        .raw_arg(wrap_in_quotes(&path))
         .creation_flags(CREATE_NO_WINDOW);
-    vec![cmd]
+    cmds.push(cmd);
+
+    cmds
 }
 
 pub fn with_command<T: AsRef<OsStr>>(path: T, app: impl Into<String>) -> Command {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -27,17 +27,18 @@ fn winebrowser_command<T: AsRef<OsStr>>(path: T) -> Command {
 
 pub fn commands<T: AsRef<OsStr>>(path: T) -> Vec<Command> {
     let mut cmds = Vec::new();
+    let path = path.as_ref();
 
     // When under Wine, try winebrowser first for seamless host integration.
     if is_running_under_wine() {
-        cmds.push(winebrowser_command(&path));
+        cmds.push(winebrowser_command(path));
     }
 
     let mut cmd = Command::new("cmd");
     cmd.arg("/c")
         .arg("start")
         .raw_arg("\"\"")
-        .raw_arg(wrap_in_quotes(&path))
+        .raw_arg(wrap_in_quotes(path))
         .creation_flags(CREATE_NO_WINDOW);
     cmds.push(cmd);
 


### PR DESCRIPTION
When running a Windows-targeted binary (`.exe`) under Wine, open requests previously fell back to Wine's bundled `explorer.exe`, which lacks proper host desktop integration.

This change detects the Wine environment at runtime (via `WINEPREFIX`, `WINELOADER`, or `WINEDEBUG` env variables) and prepends a `winebrowser` command to the launcher list, because `winebrowser` is [Wine's official utility](https://gitlab.winehq.org/wine/wine/-/wikis/Commands/winebrowser) for forwarding file/URL requests to the host OS's default handler (e.g., `xdg-open` on Linux, `open` on macOS).

If `winebrowser` is unavailable or fails, the existing `cmd /c start` is used as a fallback. No public API changes or compile-time flags are introduced.

Screencapture of the changes (with a before/after) to compare, on macOS, using a freshly installed `wine` (using `brew install --cask wine@staging`):

https://github.com/user-attachments/assets/9c549215-8262-4176-872d-1d7e2dc8a1f5

Screenshot running on Linux Mint, with a Wine instance wrapped by Lutris, starting correctly my default file browser Dolphin:

<img width="785" height="506" alt="image" src="https://github.com/user-attachments/assets/ca01208a-dd9b-4791-b843-189d2d1061b2" />

I have not bumped the `Cargo.toml` version (it should be the patch level) nor the `changelog.md` as I do not know whether you have your own release workflow. The changelog gives me the impression it's automatically updated, given the comment blocks?

EDIT: LLM usage disclosure: I've used the web interface of Qwen3.6-Plus at chat.qwen.ai to get guidance on what could be different implementation paths. It provided sample code snippets that looked good to me.