### PR TITLE
fix: use PowerShell instead of wslview on WSL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,6 @@ test = false
 doc = false
 name = "open"
 
-[target.'cfg(all(unix, not(macos)))'.dependencies]
-pathdiff = "0.2.0"
-
 [target.'cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd", target_os = "illumos", target_os = "solaris", target_os = "aix", target_os = "hurd"))'.dependencies]
 is-wsl = "0.4.0"
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ $ open <path-or-url>
 # Windows
 $ start <path-or-url>
 # Linux
-$ xdg-open <path-or-url> || gio open <path-or-url> || gnome-open <path-or-url> || kde-open <path-or-url> || wslview <path-or-url>
+$ xdg-open <path-or-url> || gio open <path-or-url> || gnome-open <path-or-url> || kde-open <path-or-url>
+# WSL
+$ powershell.exe -NoProfile -Command "Start-Process -FilePath '<path-or-url>'" || xdg-open <path-or-url> || gio open <path-or-url> || gnome-open <path-or-url> || kde-open <path-or-url>
 ```
 
 To open a web browser, see the [webbrowser](https://docs.rs/webbrowser) crate, which offers functionality for that specific case.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@
 //!
 // On a console, without a window manager, results will likely be poor. The openers expect to be able to open in a new or existing window, something that consoles lack.
 //!
-//! On Windows WSL, `wslview` is tried first, then `xdg-open`. In other UNIX environments, `xdg-open` is tried first. If this fails, a sequence of other openers is tried.
+//! On Windows WSL, PowerShell is tried first to delegate to the Windows default handler, then `xdg-open`. In other UNIX environments, `xdg-open` is tried first. If this fails, a sequence of other openers is tried.
 //!
 //! Currently the `BROWSER` environment variable is ignored even for `http:` and `https:` URLs unless the opener being used happens to respect it.
 //!
@@ -398,6 +398,21 @@ mod haiku;
 
 #[cfg(target_os = "redox")]
 mod redox;
+
+#[cfg(any(
+    test,
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "dragonfly",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "illumos",
+    target_os = "solaris",
+    target_os = "aix",
+    target_os = "hurd"
+))]
+mod wsl;
 
 #[cfg(any(
     target_os = "linux",

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,61 +1,32 @@
-use std::{
-    env,
-    ffi::{OsStr, OsString},
-    path::{Path, PathBuf},
-    process::Command,
-};
+use std::{ffi::OsStr, process::Command};
 
 pub fn commands<T: AsRef<OsStr>>(path: T) -> Vec<Command> {
     let path = path.as_ref();
-    let mut commands: Vec<(&str, Vec<&OsStr>)> = vec![];
+    let is_wsl = is_wsl::is_wsl();
+    let mut commands = vec![];
 
-    let wsl_path = wsl_path(path);
-    if is_wsl::is_wsl() {
-        commands.push(("wslview", vec![&wsl_path]));
+    if is_wsl {
+        commands.push(crate::wsl::command(path));
     }
 
-    commands.extend_from_slice(&[
-        ("xdg-open", vec![&path]),
+    let fallback_commands = [
+        ("xdg-open", vec![path]),
         ("gio", vec![OsStr::new("open"), path]),
         ("gnome-open", vec![path]),
         ("kde-open", vec![path]),
-    ]);
+    ];
+
+    commands.extend(fallback_commands.iter().map(|(command, args)| {
+        let mut cmd = Command::new(command);
+        cmd.args(args);
+        cmd
+    }));
 
     commands
-        .iter()
-        .map(|(command, args)| {
-            let mut cmd = Command::new(command);
-            cmd.args(args);
-            cmd
-        })
-        .collect()
 }
 
 pub fn with_command<T: AsRef<OsStr>>(path: T, app: impl Into<String>) -> Command {
     let mut cmd = Command::new(app.into());
     cmd.arg(path.as_ref());
     cmd
-}
-
-// Polyfill to workaround absolute path bug in wslu(wslview). In versions before
-// v3.1.1, wslview is unable to find absolute paths. `wsl_path` converts an
-// absolute path into a relative path starting from the current directory. If
-// the path is already a relative path or the conversion fails the original path
-// is returned.
-fn wsl_path<T: AsRef<OsStr>>(path: T) -> OsString {
-    fn path_relative_to_current_dir<T: AsRef<OsStr>>(path: T) -> Option<PathBuf> {
-        let path = Path::new(&path);
-
-        if path.is_relative() {
-            return None;
-        }
-
-        let base = env::current_dir().ok()?;
-        pathdiff::diff_paths(path, base)
-    }
-
-    match path_relative_to_current_dir(&path) {
-        None => OsString::from(&path),
-        Some(relative) => OsString::from(relative),
-    }
 }

--- a/src/wsl.rs
+++ b/src/wsl.rs
@@ -1,0 +1,166 @@
+use std::{
+    env,
+    ffi::{OsStr, OsString},
+    process::Command,
+};
+
+pub fn command(path: &OsStr) -> Command {
+    command_with_distro(path, env::var("WSL_DISTRO_NAME").ok().as_deref())
+}
+
+fn command_with_distro(path: &OsStr, distro: Option<&str>) -> Command {
+    let path = interop_path(path, distro);
+    let mut cmd = Command::new("powershell.exe");
+    cmd.arg("-NoProfile")
+        .arg("-Command")
+        .arg(powershell_start_process_command(&path));
+    cmd
+}
+
+fn powershell_start_process_command(path: &OsStr) -> OsString {
+    let mut command = OsString::from("Start-Process -FilePath ");
+    command.push(powershell_single_quoted(path));
+    command
+}
+
+fn powershell_single_quoted(value: &OsStr) -> OsString {
+    let mut quoted = String::from("'");
+    for chr in value.to_string_lossy().chars() {
+        if chr == '\'' {
+            quoted.push_str("''");
+        } else {
+            quoted.push(chr);
+        }
+    }
+    quoted.push('\'');
+    OsString::from(quoted)
+}
+
+/// Converts WSL paths into paths Windows can open through interop.
+///
+/// Paths that are already Windows-compatible, relative paths, paths without a
+/// known distro, and non-UTF-8 paths are returned unchanged.
+///
+/// Examples:
+///
+/// * `https://example.com` -> `https://example.com`
+/// * `/mnt/c/Users/alice/doc.pdf` -> `C:\Users\alice\doc.pdf`
+/// * `/home/alice/doc.pdf` with distro `Ubuntu` -> `\\wsl$\Ubuntu\home\alice\doc.pdf`
+fn interop_path(path: &OsStr, distro: Option<&str>) -> OsString {
+    let path = match path.to_str() {
+        Some(path) => path,
+        None => return path.to_owned(),
+    };
+
+    if !path.starts_with('/') {
+        return OsString::from(path);
+    }
+
+    if let Some(path) = drvfs_path(path) {
+        return OsString::from(path);
+    }
+
+    match distro {
+        Some(distro) if !distro.is_empty() => {
+            OsString::from(format!(r"\\wsl$\{distro}{}", path.replace('/', r"\")))
+        }
+        _ => OsString::from(path),
+    }
+}
+
+/// Converts WSL drvfs mount paths into Windows drive paths.
+///
+/// Returns `None` when the path is not a `/mnt/<drive>` path, when the drive is
+/// not an ASCII letter, or when extra path components are missing the separator.
+///
+/// Examples:
+///
+/// * `/mnt/c` -> `C:\`
+/// * `/mnt/c/Users/alice/doc.pdf` -> `C:\Users\alice\doc.pdf`
+/// * `/home/alice/doc.pdf` -> `None`
+fn drvfs_path(path: &str) -> Option<String> {
+    let rest = path.strip_prefix("/mnt/")?;
+    let mut chars = rest.chars();
+    let drive = chars.next()?;
+
+    if !drive.is_ascii_alphabetic() {
+        return None;
+    }
+
+    let rest = chars.as_str();
+    if rest.is_empty() {
+        return Some(format!("{}:\\", drive.to_ascii_uppercase()));
+    }
+
+    let rest = rest.strip_prefix('/')?;
+    Some(format!(
+        "{}:\\{}",
+        drive.to_ascii_uppercase(),
+        rest.replace('/', r"\")
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{ffi::OsStr, process::Command};
+
+    use super::{command, command_with_distro, interop_path};
+
+    fn command_args(command: &Command) -> Vec<String> {
+        command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn command_starts_with_powershell() {
+        let command = command(OsStr::new("https://example.com"));
+
+        assert_eq!(
+            command.get_program(),
+            "powershell.exe",
+            "avoid wslview as it's unmaintained"
+        );
+        assert_eq!(
+            command_args(&command),
+            [
+                "-NoProfile",
+                "-Command",
+                "Start-Process -FilePath 'https://example.com'"
+            ]
+        );
+    }
+
+    #[test]
+    fn command_quotes_powershell_metacharacters() {
+        let command = command_with_distro(OsStr::new("https://example.com/a'b;c"), Some("Ubuntu"));
+        let args = command_args(&command);
+
+        assert_eq!(
+            args,
+            [
+                "-NoProfile",
+                "-Command",
+                "Start-Process -FilePath 'https://example.com/a''b;c'"
+            ]
+        );
+    }
+
+    #[test]
+    fn interop_path_converts_absolute_linux_paths_to_unc_paths() {
+        assert_eq!(
+            interop_path(OsStr::new("/home/alice/doc.pdf"), Some("Ubuntu")),
+            r"\\wsl$\Ubuntu\home\alice\doc.pdf"
+        );
+    }
+
+    #[test]
+    fn interop_path_converts_drvfs_paths_to_windows_paths() {
+        assert_eq!(
+            interop_path(OsStr::new("/mnt/c/Users/alice/doc.pdf"), Some("Ubuntu")),
+            r"C:\Users\alice\doc.pdf"
+        );
+        assert_eq!(interop_path(OsStr::new("/mnt/d"), Some("Ubuntu")), r"D:\");
+    }
+}


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

- Replace the WSL-specific `wslview` opener with a PowerShell `Start-Process -FilePath` command invocation.
- Quote the target as PowerShell data, and convert WSL paths before invoking PowerShell: `/mnt/<drive>/...` becomes a Windows drive path, while other absolute WSL paths become UNC paths under `\\wsl$\<distro>`.
- Preserve the existing Unix fallbacks after the WSL opener, update README/API docs, and remove the now-unused `pathdiff` dependency.

## Issue

Fixes #122.

Reference: https://github.com/Byron/open-rs/issues/122#issuecomment-4792464809

## Validation

- `cargo test`
- `cargo check --target aarch64-unknown-linux-gnu --tests`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo +1.82.0 check --tests`
- `cargo +1.62.0 check --tests` was attempted, but dependency resolution selected `libc v0.2.186`, which requires rustc 1.65 before this crate is checked.
- `codex review --commit 827c0e069d6033aa7c265d41b42a968d835ab45d` returned no actionable findings after the review follow-ups.